### PR TITLE
🐛 bug: 앨범 커버 미반환 문제

### DIFF
--- a/src/pages/components/MusicCard/SpotifySearch.ts
+++ b/src/pages/components/MusicCard/SpotifySearch.ts
@@ -42,8 +42,8 @@ export class SpotifySearch {
     this.checkAuthCode();
   }
   /**
-   * 인증 성공 후 UI 업데이트 
-   
+   * 인증 성공 후 UI 업데이트
+   */
   private updateUIAfterAuth(): void {
     // 성공 메시지 표시
     const successMessage = document.createElement('div');
@@ -52,6 +52,14 @@ export class SpotifySearch {
     <p>Spotify 로그인 성공!</p>
     <p>이제 음악을 재생할 수 있습니다.</p>
   `;
+
+    // 메시지를 표시하기 전에 이전 콘텐츠 저장
+    if (
+      this.resultsContainer.innerHTML &&
+      this.resultsContainer.innerHTML !== ''
+    ) {
+      this.previousContent = this.resultsContainer.innerHTML;
+    }
 
     // 메시지 표시
     this.resultsContainer.innerHTML = '';
@@ -68,8 +76,6 @@ export class SpotifySearch {
       }
     }, 3000);
   }
-    */
-  //해당코드는 디라이렉트 후 기존 재생 저장 기능으로 인해 주석처리 되었습니다.
 
   // 토큰이 만료되었는지 확인하는 메서드 추가
   private isTokenExpired(): boolean {

--- a/src/pages/components/MusicCard/SpotifySearch.ts
+++ b/src/pages/components/MusicCard/SpotifySearch.ts
@@ -54,10 +54,7 @@ export class SpotifySearch {
   `;
 
     // 메시지를 표시하기 전에 이전 콘텐츠 저장
-    if (
-      this.resultsContainer.innerHTML &&
-      this.resultsContainer.innerHTML !== ''
-    ) {
+    if (this.resultsContainer.innerHTML && this.resultsContainer.innerHTML !== '') {
       this.previousContent = this.resultsContainer.innerHTML;
     }
 
@@ -65,8 +62,20 @@ export class SpotifySearch {
     this.resultsContainer.innerHTML = '';
     this.resultsContainer.appendChild(successMessage);
 
+    // 저장된 검색 정보가 있는지 확인
+    const savedSearch = localStorage.getItem('spotify_last_search');
+
     // 3초 후 메시지 제거
-    setTimeout(() => {
+    setTimeout(async () => {
+      // 저장된 검색 정보가 있으면 복원 시도
+      if (savedSearch) {
+        const searchRestored = await this.restoreLastSearch();
+        if (searchRestored) {
+          // 검색 정보 복원에 성공했으면 여기서 종료
+          return;
+        }
+      }
+
       // 이전 콘텐츠가 있으면 복원
       if (this.previousContent) {
         this.resultsContainer.innerHTML = this.previousContent;


### PR DESCRIPTION
## PR 유형

- [x] 버그 수정


## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세
- `updateUIAfterAuth` 메서드를 다시 구현하여 활성화하겠습니다.
- 문제를 해결하기 위해 `updateUIAfterAuth` 메서드를 개선했습니다. 이전 버전에서는 3초 후에 무조건 기존 콘텐츠를 복원하거나 "음악을 검색해 보세요" 메시지를 표시했습니다. 하지만 이미 음악 카드가 렌더링된 상태에서는 이 동작이 원하지 않는 결과를 초래했습니다.

## 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 예시 : resolves #1 -->

resolves #
