### PR TITLE
✨ feat: Tenor API에서 GIF를 가져올 때 가로형 이미지만을 가져오게 함

### DIFF
--- a/src/utils/tenor.ts
+++ b/src/utils/tenor.ts
@@ -4,7 +4,7 @@ const tenorApiKey = import.meta.env.VITE_TENOR_APIKEY;
  *
  * @param tag1 검색 태그 1
  * @param tag2 검색 태그 2
- * @description 두 개의 태그를 조합하여 tenor api를 이용 -> GIF URL을 가져오는 함수
+ * @description 두 개의 태그를 조합, tenor api를 이용하여 GIF URL을 가져오는 함수. 사진의 비율을 체크해 가로 세로 비율이 1.5 이상인 경우에만 URL을 반환한다.
  * @returns gif 파일의 URL
  */
 async function getGifUrlByTags(
@@ -12,18 +12,47 @@ async function getGifUrlByTags(
   tag2: string,
 ): Promise<string | null> {
   const query = `${encodeURIComponent(tag1)} ${encodeURIComponent(tag2)}`;
-  const response = await fetch(
-    `https://tenor.googleapis.com/v2/search?q=${query}&key=${tenorApiKey}&limit=1&random=true`,
-  );
+  let gifUrl = '';
+  let isLandscape = false;
+  let attempts = 0;
+  const maxAttempts = 10;
 
-  if (!response.ok) {
-    console.error('Tenor API 호출 실패:', response.statusText);
-    return null;
+  while (!isLandscape && attempts < maxAttempts) {
+    attempts++;
+
+    const response = await fetch(
+      `https://tenor.googleapis.com/v2/search?q=${query}&key=${tenorApiKey}&limit=1&random=true`,
+    );
+
+    if (!response.ok) {
+      console.error('Tenor API 호출 실패:', response.statusText);
+      return null;
+    }
+
+    const data = await response.json();
+    const result = data.results?.[0];
+    const dims = result?.media_formats?.gif?.dims;
+
+    if (isLandscapeRatio(dims)) {
+      gifUrl = result.media_formats.gif.url;
+      isLandscape = true;
+    }
   }
 
-  const data = await response.json();
-  const gifUrl = data.results?.[0]?.media_formats?.gif?.url;
-  return gifUrl ?? null;
+  return gifUrl;
+}
+
+/**
+ *
+ * @param dims 가로 세로 크기가 담긴 Json 배열
+ * @returns true: 가로 세로 비율이 1.5 이상인 경우 (16:9 비율의 경우 ratio가 1.77)
+ */
+function isLandscapeRatio(dims: number[]) {
+  const width = dims[0];
+  const height = dims[1];
+  const ratio = width / height;
+
+  return ratio > 1.5;
 }
 
 export { getGifUrlByTags };


### PR DESCRIPTION
## PR 유형

- [x] 새로운 기능 추가
- [x] 버그 수정

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세

Tenor API를 사용해 GIF를 가져올 때, 가로/세로 비율이 1.5 이상인 이미지만 선택되도록 변경하였습니다..
조건을 만족하지 않는 경우 최대 10번까지 재시도하며, 조건에 맞는 GIF가 없을 경우 null을 반환합니다..

## 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 예시 : resolves #1 -->

resolves #51 
