### PR TITLE
Netlify Build 에러 해결

### DIFF
--- a/src/pages/components/MusicCard/SpotifySearch.ts
+++ b/src/pages/components/MusicCard/SpotifySearch.ts
@@ -352,13 +352,13 @@ export class SpotifySearch {
     console.log('Spotify 검색 컴포넌트가 초기화되었습니다.');
   }
 
-  /**
-   * 검색 입력 필드 렌더링 - 사용하지 않음
-   */
-  private renderSearchInput(): void {
-    // 검색 입력 UI를 렌더링하지 않음
-    // 이 메서드는 더 이상 initialize()에서 호출되지 않음
-  }
+  // /**
+  //  * 검색 입력 필드 렌더링 - 사용하지 않음
+  //  */
+  // private renderSearchInput(): void {
+  //   // 검색 입력 UI를 렌더링하지 않음
+  //   // 이 메서드는 더 이상 initialize()에서 호출되지 않음
+  // }
 
   /**
    * 트랙 검색

--- a/src/pages/components/MusicCard/index.ts
+++ b/src/pages/components/MusicCard/index.ts
@@ -41,9 +41,11 @@ export class MusicCard {
         this.track.album.images &&
         this.track.album.images.length > 0
       ) {
-        const albumImage = this.track.album.images.reduce((prev, current) => {
-          return (prev.width || 0) > (current.width || 0) ? prev : current;
-        }, this.track.album.images[0]);
+        const albumImage = (
+          this.track.album.images as { url: string; width: number }[]
+        ).reduce((prev, current) =>
+          prev.width > current.width ? prev : current,
+        );
 
         trackCard.style.backgroundImage = `url(${albumImage.url})`;
         trackCard.style.backgroundSize = 'cover';

--- a/src/pages/components/MusicCard/init.ts
+++ b/src/pages/components/MusicCard/init.ts
@@ -1,5 +1,5 @@
 // src/pages/components/MusicCard/init.ts
-// import { SpotifySearch } from './SpotifySearch';
+import { SpotifySearch } from './SpotifySearch';
 import { getSongRecommendation } from '../../../utils/openai';
 
 // document.addEventListener('DOMContentLoaded', async () => {
@@ -51,7 +51,7 @@ export async function fetchMusic(container: HTMLElement) {
   }
   console.log('스포티파이 실행');
   // SpotifySearch 컴포넌트 초기화
-  // const spotifySearch = new SpotifySearch(container);
+  new SpotifySearch(container);
 
   // URL 파라미터 확인
   const urlParams = new URLSearchParams(window.location.search);

--- a/src/pages/components/MusicCard/init.ts
+++ b/src/pages/components/MusicCard/init.ts
@@ -1,5 +1,5 @@
 // src/pages/components/MusicCard/init.ts
-import { SpotifySearch } from './SpotifySearch';
+// import { SpotifySearch } from './SpotifySearch';
 import { getSongRecommendation } from '../../../utils/openai';
 
 // document.addEventListener('DOMContentLoaded', async () => {
@@ -51,7 +51,7 @@ export async function fetchMusic(container: HTMLElement) {
   }
   console.log('스포티파이 실행');
   // SpotifySearch 컴포넌트 초기화
-  const spotifySearch = new SpotifySearch(container);
+  // const spotifySearch = new SpotifySearch(container);
 
   // URL 파라미터 확인
   const urlParams = new URLSearchParams(window.location.search);

--- a/src/utils/openai.ts
+++ b/src/utils/openai.ts
@@ -132,7 +132,7 @@ export async function getSongRecommendation(): Promise<string | null> {
     const recommendation = completion.choices[0]?.message.content?.trim();
 
     console.log('GPT 추천 노래:', recommendation);
-    return recommendation;
+    return recommendation ?? null;
   } catch (error) {
     console.error('노래 추천 중 오류 발생:', error);
     return null;


### PR DESCRIPTION
## PR 유형

- [x] 버그 수정
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세

에러 메세지에 나온 오류들만 해결하였습니다...

<details>
<summary>Netlify Build 0.2.0 오류 내용</summary>
9:22:33 AM: Netlify Build                                                 
9:22:33 AM: ────────────────────────────────────────────────────────────────
9:22:33 AM: ​
9:22:33 AM: ❯ Version
9:22:33 AM:   @netlify/build 33.1.3
9:22:33 AM: ​
9:22:33 AM: ❯ Flags
9:22:33 AM:   accountId: 65a8bad0ab924f38d9cd266a
9:22:33 AM:   baseRelDir: true
9:22:33 AM:   buildId: 682e6e34cfaac3000837a30b
9:22:33 AM:   deployId: 682e6e34cfaac3000837a30d
9:22:33 AM: ​
9:22:33 AM: ❯ Current directory
9:22:33 AM:   /opt/build/repo
9:22:33 AM: ​
9:22:33 AM: ❯ Config file
9:22:33 AM:   No config file was defined: using default values.
9:22:33 AM: ​
9:22:33 AM: ❯ Context
9:22:33 AM:   deploy-preview
9:22:33 AM: ​
9:22:33 AM: Build command from Netlify app                                
9:22:33 AM: ────────────────────────────────────────────────────────────────
9:22:33 AM: ​
9:22:33 AM: $ npm run build
9:22:33 AM: > js-project-sample@0.0.0 build
9:22:33 AM: > tsc && vite build
9:22:35 AM: Failed during stage 'building site': Build script returned non-zero exit code: 2 (https://ntl.fyi/exit-code-2)
9:22:35 AM: src/pages/components/MusicCard/SpotifySearch.ts(358,11): error TS6133: 'renderSearchInput' is declared but its value is never read.
9:22:35 AM: src/pages/components/MusicCard/index.ts(45,24): error TS2339: Property 'width' does not exist on type '{ url: string; }'.
9:22:35 AM: src/pages/components/MusicCard/index.ts(45,47): error TS2339: Property 'width' does not exist on type '{ url: string; }'.
9:22:35 AM: src/pages/components/MusicCard/init.ts(54,9): error TS6133: 'spotifySearch' is declared but its value is never read.
9:22:35 AM: src/utils/openai.ts(135,5): error TS2322: Type 'string | undefined' is not assignable to type 'string | null'.
9:22:35 AM:   Type 'undefined' is not assignable to type 'string | null'.
9:22:35 AM: ​
9:22:35 AM: "build.command" failed                                        
9:22:35 AM: ────────────────────────────────────────────────────────────────
9:22:35 AM: ​
9:22:35 AM:   Error message
9:22:35 AM:   Command failed with exit code 2: npm run build (https://ntl.fyi/exit-code-2)
9:22:35 AM: ​
9:22:35 AM:   Error location
9:22:35 AM:   In Build command from Netlify app:
9:22:35 AM:   npm run build
9:22:35 AM: ​
9:22:35 AM:   Resolved config
9:22:35 AM:   build:
9:22:35 AM:     command: npm run build
9:22:35 AM:     commandOrigin: ui
9:22:35 AM:     environment:
9:22:35 AM:       - REVIEW_ID
9:22:35 AM:       - VITE_CALLBACK_URI
9:22:35 AM:       - VITE_OPENAI_APIKEY
9:22:35 AM:       - VITE_SPOTIFY_CLIENT_ID
9:22:35 AM:       - VITE_SPOTIFY_CLIENT_SECRET
9:22:35 AM:       - VITE_TENOR_APIKEY
9:22:35 AM:     publish: /opt/build/repo/dist
9:22:35 AM:     publishOrigin: ui
9:22:35 AM: Build failed due to a user error: Build script returned non-zero exit code: 2
9:22:35 AM: Failing build: Failed to build site
9:22:35 AM: Finished processing build request in 21.798s
</details>

## 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 예시 : resolves #1 -->

resolves #59 
