### PR TITLE
🐛 fix: 일기 내용이 로컬 스토리지에 없을 때, result.html에 접근 가능한 오류 해결

### DIFF
--- a/src/pages/result.ts
+++ b/src/pages/result.ts
@@ -84,6 +84,14 @@ async function dataFetch(): Promise<void> {
   showLoading(true);
 
   try {
+    const diary = localStorage.getItem('diary');
+
+    if (!diary) {
+      alert('일기 내용 없음. 일기를 먼저 작성해주세요.');
+      window.location.href = '/src/pages/diary.html';
+      return;
+    }
+
     const [image, summary, bestQuote, empathy, tenor] = await Promise.all([
       fetchImage(),
       fetchSummary(),


### PR DESCRIPTION
## PR 유형

- [x] 버그 수정

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세

result 페이지에서 데이터를 가져올 때 diary가 없다면 diary.html로 이동합니다.

## 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 예시 : resolves #1 -->

resolves #71 
